### PR TITLE
Add advance to <= and <> operator cases

### DIFF
--- a/src/tokenizer.py
+++ b/src/tokenizer.py
@@ -79,6 +79,7 @@ class Tokenizer:
                 location = self.current_location()
                 d = self.__advance()
                 if c == '<' and d in '>=':
+                    self.__advance()
                     return SymbolToken(c + d, location)
                 elif c in '>:' and d == '=':
                     self.__advance()


### PR DESCRIPTION
The `=` and `>` were not consumed, and they showed up as nodes in the AST.